### PR TITLE
Fix POD - add description to NAME

### DIFF
--- a/lib/Data/CompactReadonly.pm
+++ b/lib/Data/CompactReadonly.pm
@@ -11,7 +11,7 @@ our $VERSION = '0.1.0';
 
 =head1 NAME
 
-Data::CompactReadonly
+Data::CompactReadonly - create Compact Read Only Databases
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Data-CompactReadonly.
We thought you might be interested in it too.

    Description: Fix POD - add description to NAME
     in order to get whatis entry in manpage
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2023-10-28
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libdata-compactreadonly-perl/raw/master/debian/patches/whatis.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
